### PR TITLE
Removes the channel action and sets charmhub channel manually

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -25,13 +25,10 @@ jobs:
           name: tested-charm
       - name: Move charm in current directory
         run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
-      - name: Select Charmhub channel
-        uses: canonical/charming-actions/channel@2.3.0
-        id: channel
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.3.0
         with:
           built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+          channel: latest/edge


### PR DESCRIPTION
The `channel` action from `charming-actions` choses the `Charmhub` channel based on Github event and the branch name.
We don't utilise those features and we publish to `lates/edge` by default (we use the push + default branch which will make the action chose latest/edge)
As the action doesn't support scheduled runs I suggest to use the `latest/edge` channel by default and make a change when that is needed.
<img width="682" alt="Screenshot 2023-07-05 at 17 26 00" src="https://github.com/canonical/sdcore-github-workflows/assets/26838825/5e827a9d-104c-4578-be6b-f5dfc312a1a9">
