### PR TITLE
Makes the workflow usable from different projects

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,8 +1,10 @@
 name: Sync Issues to JIRA
 
 on:
-  issues:
-    types: [opened, reopened, closed]
+  workflow_call:
+    secrets:
+      JIRA_URL:
+        required: true
 
 jobs:
   update:


### PR DESCRIPTION
This change is needed so sdcore charms can use this workflow.