### PR TITLE
Bumps LXD version to 5.17/stable

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.13/stable
+          channel: 5.17/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.13/stable
+          channel: 5.17/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:


### PR DESCRIPTION
Bumps LXD version to `5.17/stable` as `5.13/stable` is no longer available.