### PR TITLE
fix: Replacing specific version of the LXD snap with latest/stable

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.17/stable
+          channel: latest/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.17/stable
+          channel: latest/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:


### PR DESCRIPTION
Replaces fixed version of the LXD snap with `latest/stable`. 
CONTEXT:
Once in a while, older versions of the LXD snap are getting removed. When this happens, our tests start failing. LXD is used by Charmcraft to spin up a charm builder. This means that the LXD version doesn't really affect our software, so I think it's safe to use `latest/stable` instead of a fixed version.