### PR TITLE
fix: Read metadata from charmcraft.yaml

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Move charm in current directory
         run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
       - name: Upload charm to Charmhub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        uses: canonical/charming-actions/upload-charm@bc8d4ee58ddf99c6f13fc80e8a14dfe1e68a8ea6
         with:
           built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"


### PR DESCRIPTION
# Description

The charming actions project recently added support to read metadata from charmcraft.yaml. However this is not in a current release so we point to the specific git commit.

## Reference
- https://github.com/canonical/charming-actions/pull/132