### PR TITLE
fix: Adding `working-directory` as an input variable to the terraform workflow

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -5,6 +5,12 @@ name: Check Terraform Module
 
 on:
   workflow_call:
+    inputs:
+      working-directory:
+        description: The directory that stores the Terraform modules
+        required: false
+        default: ./terraform
+        type: string
 
 jobs:
   check-terraform:
@@ -12,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./terraform
+        working-directory: ${{ inputs.working-directory }}
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
The Terraform modules could be stored in different directories in the repositories. If we search them only in a default folder, this causes the issues. Adding `working-directory` path as an input variable help to customize this path according to repository requirements.