### PR TITLE
feat: Publish charms and snaps to branch on pull request

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -38,15 +38,14 @@ jobs:
       # - name: Run integration tests
       #   run: tox -e integration
       - name: Install deps
-        run: snap install charmcraft --classic
+        run: sudo snap install charmcraft --classic
       - name: Build Charm
         run: charmcraft pack
       - name: Archive Tested Charm
         uses: actions/upload-artifact@v4
-        if: ${{ github.ref_name == 'main' }}
         with:
           name: tested-charm
-          path: .tox/**/${{ inputs.charm-file-name }}
+          path: ./${{ inputs.charm-file-name }}
           retention-days: 5
       - name: Archive charmcraft logs
         if: failure()

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -21,22 +21,24 @@ jobs:
         uses: canonical/setup-lxd@main
         with:
           channel: latest/stable
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          juju-channel: 3.4/stable
-          provider: microk8s
-          channel: 1.27-strict/stable
-          microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"
-      - name: Enable Multus addon
-        continue-on-error: true
-        run: |
-          sudo microk8s addons repo add community https://github.com/canonical/microk8s-community-addons --reference feat/strict-fix-multus
-          sudo microk8s enable multus
-          sudo microk8s kubectl -n kube-system rollout status daemonset/kube-multus-ds
-          sudo microk8s kubectl auth can-i create network-attachment-definitions
-      - name: Run integration tests
-        run: tox -e integration
+      # - name: Setup operator environment
+      #   uses: charmed-kubernetes/actions-operator@main
+      #   with:
+      #     juju-channel: 3.4/stable
+      #     provider: microk8s
+      #     channel: 1.27-strict/stable
+      #     microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"
+      # - name: Enable Multus addon
+      #   continue-on-error: true
+      #   run: |
+      #     sudo microk8s addons repo add community https://github.com/canonical/microk8s-community-addons --reference feat/strict-fix-multus
+      #     sudo microk8s enable multus
+      #     sudo microk8s kubectl -n kube-system rollout status daemonset/kube-multus-ds
+      #     sudo microk8s kubectl auth can-i create network-attachment-definitions
+      # - name: Run integration tests
+      #   run: tox -e integration
+      - name: Build Charm
+        run: charmcraft pack
       - name: Archive Tested Charm
         uses: actions/upload-artifact@v4
         if: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -21,31 +21,27 @@ jobs:
         uses: canonical/setup-lxd@main
         with:
           channel: latest/stable
-      # - name: Setup operator environment
-      #   uses: charmed-kubernetes/actions-operator@main
-      #   with:
-      #     juju-channel: 3.4/stable
-      #     provider: microk8s
-      #     channel: 1.27-strict/stable
-      #     microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"
-      # - name: Enable Multus addon
-      #   continue-on-error: true
-      #   run: |
-      #     sudo microk8s addons repo add community https://github.com/canonical/microk8s-community-addons --reference feat/strict-fix-multus
-      #     sudo microk8s enable multus
-      #     sudo microk8s kubectl -n kube-system rollout status daemonset/kube-multus-ds
-      #     sudo microk8s kubectl auth can-i create network-attachment-definitions
-      # - name: Run integration tests
-      #   run: tox -e integration
-      - name: Install Charmcraft Snap
-        run: sudo snap install charmcraft --classic
-      - name: Build Charm
-        run: charmcraft pack
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.4/stable
+          provider: microk8s
+          channel: 1.27-strict/stable
+          microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"
+      - name: Enable Multus addon
+        continue-on-error: true
+        run: |
+          sudo microk8s addons repo add community https://github.com/canonical/microk8s-community-addons --reference feat/strict-fix-multus
+          sudo microk8s enable multus
+          sudo microk8s kubectl -n kube-system rollout status daemonset/kube-multus-ds
+          sudo microk8s kubectl auth can-i create network-attachment-definitions
+      - name: Run integration tests
+        run: tox -e integration
       - name: Archive Tested Charm
         uses: actions/upload-artifact@v4
         with:
           name: tested-charm
-          path: ./${{ inputs.charm-file-name }}
+          path: .tox/**/${{ inputs.charm-file-name }}
           retention-days: 5
       - name: Archive charmcraft logs
         if: failure()

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -37,6 +37,8 @@ jobs:
       #     sudo microk8s kubectl auth can-i create network-attachment-definitions
       # - name: Run integration tests
       #   run: tox -e integration
+      - name: Install deps
+        run: snap install charmcraft --classic
       - name: Build Charm
         run: charmcraft pack
       - name: Archive Tested Charm

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -37,7 +37,7 @@ jobs:
       #     sudo microk8s kubectl auth can-i create network-attachment-definitions
       # - name: Run integration tests
       #   run: tox -e integration
-      - name: Install deps
+      - name: Install Charmcraft Snap
         run: sudo snap install charmcraft --classic
       - name: Build Charm
         run: charmcraft pack

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -14,6 +14,10 @@ on:
         default: latest
         description: Name of the charmhub track to publish
         type: string
+      branch-name:
+        default:
+        description: An additional branch name to add to the track
+        type: string
     secrets:
       CHARMCRAFT_AUTH:
         required: true
@@ -38,7 +42,7 @@ jobs:
           built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: ${{ inputs.track-name }}/edge
+          channel: ${{ inputs.track-name }}/edge${{ inputs.branch-name }}
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This change will push to a branch under edge with the same name as the branch on which the job runs.

For example, a PR using a branch called `TELCO-1082-Publish-charms-and-snaps-to-branch-on-pull-request` would look like the following after a successful run:

```
charmcraft status sdcore-upf-k8s
Track    Base                  Channel                                                             Version    Revision    Resources                                  Expires at                                                      
latest   ubuntu 22.04 (amd64)  stable                                                              -          -           -                                                                                                          
                               candidate                                                           -          -           -                                                                                                          
                               beta                                                                13         13          bessd-image (r5), pfcp-agent-image (r5)                                                                    
                               edge                                                                21         21          bessd-image (r8), pfcp-agent-image (r7)                                                                    
1.3      ubuntu 22.04 (amd64)  stable                                                              -          -           -                                                                                                          
                               candidate                                                           -          -           -                                                                                                          
                               beta                                                                13         13          bessd-image (r5), pfcp-agent-image (r5)                                                                    
                               edge                                                                70         70          bessd-image (r16), pfcp-agent-image (r14)                                                                  
                               edge/TELCO-1082-Publish-charms-and-snaps-to-branch-on-pull-request  72         72          bessd-image (r16), pfcp-agent-image (r14)  2024-04-19T00:00:00Z                                            
```

Note that the developer must either log into the store or know the name of the branch explicitly in order to use it.