### PR TITLE
fix: Standardizing the integration tests so they all publish on push

### DIFF
--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -26,10 +26,9 @@ jobs:
 
       - name: Run integration tests
         run: tox -e integration
-        
+
       - name: Archive Tested Charm
         uses: actions/upload-artifact@v4
-        if: ${{ github.ref_name == 'main' }}
         with:
           name: tested-charm
           path: .tox/**/${{ inputs.charm-file-name }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -44,7 +44,6 @@ jobs:
         run: tox -e integration
       - name: Archive Tested Charm
         uses: actions/upload-artifact@v4
-        if: ${{ github.ref_name == 'main' }}
         with:
           name: tested-charm
           path: .tox/**/${{ inputs.charm-file-name }}


### PR DESCRIPTION
The multus based integration test archives the tested charm on success, whereas the other two do not. In order to standardize the publication of charms from branches, we need all tests to behave the same.