### PR TITLE
chore: Sanitize branch name

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -23,8 +23,20 @@ on:
         required: true
 
 jobs:
+  sanitize-branch-name:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Sanitize the branch variable
+        id: sanitize
+        run: |
+          echo "BRANCH_NAME=/${{ inputs.branch-name }} | sed 's/\//-/2g'" >> $GITHUB_OUTPUT
+        if: ${{inputs.branch-name}} != ""
+
   publish-charm:
     runs-on: ubuntu-22.04
+    needs: [sanitize-branch-name]
+    env:
+      BRANCH_NAME: "${{ needs.sanitize-branch.otuputs.BRANCH_NAME}}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +54,7 @@ jobs:
           built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: ${{ inputs.track-name }}/edge${{ inputs.branch-name }}
+          channel: ${{ inputs.track-name }}/edge${{ env.BRANCH_NAME }}
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Sanitize the branch variable
         id: sanitize
         run: |
-          echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/\//-/2g') >> $GITHUB_OUTPUT
+          echo sanitized=$(echo /${{ inputs.branch-name }} | sed 's/\//-/2g') >> $GITHUB_OUTPUT
         if: ${{inputs.branch-name}} != ""
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@bc8d4ee58ddf99c6f13fc80e8a14dfe1e68a8ea6

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -23,20 +23,8 @@ on:
         required: true
 
 jobs:
-  sanitize-branch-name:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Sanitize the branch variable
-        id: sanitize
-        run: |
-          echo "BRANCH_NAME=/${{ inputs.branch-name }} | sed 's/\//-/2g'" >> $GITHUB_OUTPUT
-        if: ${{inputs.branch-name}} != ""
-
   publish-charm:
     runs-on: ubuntu-22.04
-    needs: [sanitize-branch-name]
-    env:
-      BRANCH_NAME: "${{ needs.sanitize-branch.otuputs.BRANCH_NAME}}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,13 +36,18 @@ jobs:
           name: tested-charm
       - name: Move charm in current directory
         run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
+      - name: Sanitize the branch variable
+        id: sanitize
+        run: |
+          echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/\//-/2g') >> $GITHUB_OUTPUT
+        if: ${{inputs.branch-name}} != ""
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@bc8d4ee58ddf99c6f13fc80e8a14dfe1e68a8ea6
         with:
           built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: ${{ inputs.track-name }}/edge${{ env.BRANCH_NAME }}
+          channel: ${{ inputs.track-name }}/edge${{ steps.sanitize.outputs.sanitized }}
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Adds a new step that ensures there are no `/` characters in the branch name. This should address the issue with bots creating branches that use the `/` character.