### PR TITLE
chore: add write permission to publish charm job for Dependabot

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -24,7 +24,8 @@ on:
 
 jobs:
   publish-charm:
-    permissions: write-all
+    permissions:
+      contents: write
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   publish-charm:
+    permissions: write-all
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This is an attempt to fix the failures for Dependabot publishing developer charms.
According to [documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions), the token for Dependabot is always created with `read` permissions. This PR forces the `write` permissions on the publish charm job only.