### PR TITLE
fix: freeze lxd to 5.20/stable

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -27,16 +27,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup LXD
-        uses: canonical/setup-lxd@main
-        with:
-          channel: latest/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.4/stable
           provider: microk8s
           channel: 1.27-strict/stable
+          lxd-channel: 5.20/stable
       - name: Enable MetalLB
         if: ${{ inputs.enable-metallb == true }}
         run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:${{ inputs.metallb-range }}"


### PR DESCRIPTION
Charmcraft currently does not work with the latest lxd version (5.21/stable). This prevents other PR's being merged because of CI failures. This change freezes lxd to 5.20/stable.

https://github.com/canonical/charmcraft/issues/1640