### PR TITLE
feat: build charm in independent workflow step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-charm-under-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+    
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+            channel: 5.20/stable
+    
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive Charm Under Test
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm
+          path: "*.charm"
+          retention-days: 5

--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -5,11 +5,6 @@ name: Integration test
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Tested charm file name
-        required: true
-        type: string
 
 jobs:
   integration-test:
@@ -17,7 +12,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+    
+      - name: Fetch Charm Under Test
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm
+          path: built/
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+      
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -26,14 +31,8 @@ jobs:
           lxd-channel: 5.20/stable
 
       - name: Run integration tests
-        run: tox -e integration
-
-      - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4
-        with:
-          name: tested-charm
-          path: .tox/**/${{ inputs.charm-file-name }}
-          retention-days: 5
+        run: tox -e integration -- \
+          --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
 
       - name: Archive charmcraft logs
         if: failure()

--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -31,8 +31,9 @@ jobs:
           lxd-channel: 5.20/stable
 
       - name: Run integration tests
-        run: tox -e integration -- \
-          --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+        run: |
+          tox -e integration -- \
+            --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
 
       - name: Archive charmcraft logs
         if: failure()

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -5,11 +5,6 @@ name: Integration test
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Tested charm file name
-        required: true
-        type: string
 
 jobs:
   integration-test:
@@ -17,6 +12,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Fetch Charm Under Test
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm
+          path: built/
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -25,6 +31,7 @@ jobs:
           channel: 1.27-strict/stable
           lxd-channel: 5.20/stable
           microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"
+  
       - name: Enable Multus addon
         continue-on-error: true
         run: |
@@ -32,20 +39,19 @@ jobs:
           sudo microk8s enable multus
           sudo microk8s kubectl -n kube-system rollout status daemonset/kube-multus-ds
           sudo microk8s kubectl auth can-i create network-attachment-definitions
+  
       - name: Run integration tests
-        run: tox -e integration
-      - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4
-        with:
-          name: tested-charm
-          path: .tox/**/${{ inputs.charm-file-name }}
-          retention-days: 5
+        run: |
+          tox -e integration -- \
+            --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+    
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: charmcraft-logs
           path: /home/runner/.local/state/charmcraft/log/*.log
+  
       - name: Archive juju crashdump
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -6,10 +6,6 @@ name: Integration test
 on:
   workflow_call:
     inputs:
-      charm-file-name:
-        description: Tested charm file name
-        required: true
-        type: string
       enable-metallb:
         description: Enable MetalLB
         required: false
@@ -27,6 +23,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+    
+      - name: Fetch Charm Under Test
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm
+          path: built/
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -34,23 +41,23 @@ jobs:
           provider: microk8s
           channel: 1.27-strict/stable
           lxd-channel: 5.20/stable
+  
       - name: Enable MetalLB
         if: ${{ inputs.enable-metallb == true }}
         run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:${{ inputs.metallb-range }}"
+
       - name: Run integration tests
-        run: tox -e integration
-      - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4
-        with:
-          name: tested-charm
-          path: .tox/**/${{ inputs.charm-file-name }}
-          retention-days: 5
+        run: |
+          tox -e integration -- \
+            --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: charmcraft-logs
           path: /home/runner/.local/state/charmcraft/log/*.log
+  
       - name: Archive juju crashdump
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -6,10 +6,6 @@ name: publish-charm
 on:
   workflow_call:
     inputs:
-      charm-file-name:
-        description: Charm file name
-        required: true
-        type: string
       track-name:
         default: latest
         description: Name of the charmhub track to publish
@@ -30,26 +26,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: tested-charm
-      - name: Move charm in current directory
-        run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
+          name: built-charm
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+  
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
       - name: Sanitize the branch variable
         id: sanitize
         run: |
           echo sanitized=$(echo ${{ inputs.branch-name }} | sed 's/[/_.]/-/g' | sed "s/^/\//") >> $GITHUB_OUTPUT
         if: ${{inputs.branch-name}} != ""
+
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@bc8d4ee58ddf99c6f13fc80e8a14dfe1e68a8ea6
         with:
-          built-charm-path: ${{ inputs.charm-file-name }}
+          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: ${{ inputs.track-name }}/edge${{ steps.sanitize.outputs.sanitized }}
+  
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

We move the charm build process to its own workflow stage. We build the charm, we test it, and we publish it, all with the same artifact. 

**Do not merge! We will need to take the following actions:**
1. ~~Tag the existing workflows in this project~~ Done
3. ~~Use the tag in the individual NF CI workflows~~ (Done)
4. ~~Validate that the changes here work (see [this PR in the AMF](https://github.com/canonical/sdcore-amf-k8s-operator/pull/180))~~ (Done)
5. Merge this change here
6. Create a new major release for the github workflows (1.0.0)
7. Change the individual NF to use the new workflow v1.0.0 and adapt their integration tests code to take built charms as parameters using conftest. 

![image](https://github.com/canonical/vault-operator/assets/18486508/96adce3b-56a9-4f21-9414-916ba749354b)

## Usage

```
tox -e integration -- --charm_path=<vault charm path> \
```

## Rationale

1. This reduces the amount of resources taken by the integration tests.
2. Each step has its own precise role instead of having the built artifact be a side effect of running the integration tests.
    - In cases where the CI fails because the charm doesn't build, it's quicker to identify that this isse is build related.
    - Integration tests won't run if the build fails

## Notes
- While this change reduces the resources taken by the integration tests, it increases the total resource usage. With more workflow steps requires downloading the same dependencies multiple times. This also increases the total CI time. 
