### PR TITLE
fix: Use Canonical self-hosted runners for integration tests

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, x64, jammy, xlarge]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, x64, jammy, xlarge]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub runners currently have problem with:
```
 /usr/bin/sudo apt-get update -yqq
  E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
  E: The repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' is no longer signed.
  /usr/bin/sudo apt-get update -yqq
  E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
  E: The repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' is no longer signed.
  /usr/bin/sudo apt-get update -yqq
  E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
  E: The repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' is no longer signed.
  /usr/bin/sudo apt-get update -yqq
  E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
  E: The repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' is no longer signed.
  /usr/bin/sudo apt-get update -yqq
  E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
  E: The repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' is no longer signed.
```

This PR switches integration tests to Canonical's self-hosted runners