### PR TITLE
chore: Going back to GH runners

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: [self-hosted, linux, x64, jammy, xlarge]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: [self-hosted, linux, x64, jammy, xlarge]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Reverting #46, because we can't use Canonical's runners together with `telcobot`