### PR TITLE
fix: Changing trigger from workflow_dispatch to workflow_call

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -1,7 +1,7 @@
 name: Auto-update Charm Libraries
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       branch-name:
         description: Name of the branch to checkout


### PR DESCRIPTION
Changing trigger from `workflow_dispatch` to `workflow_call`