### PR TITLE
fix: Bumps version of the release-charm action to 2.6.0

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: "v${{ inputs.track-name }}"
       - name: Set target channel
         env:
           PROMOTE_FROM: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -40,7 +40,7 @@ jobs:
             echo "promote-to=stable" >> ${GITHUB_ENV}
           fi
       - name: Promote Charm
-        uses: canonical/charming-actions/release-charm@2.4.0
+        uses: canonical/charming-actions/release-charm@2.6.0
         with:
           base-channel: 22.04
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}


### PR DESCRIPTION
- Bumps the version of the `release-charm` action to 2.6.0 to support promotion of the charms not having the `metadata.yaml`
- Makes sure the right branch is checked out for promotion run