### PR TITLE
chore: Approves the PR and enables auto-merge of libs regardless of the actor

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -59,13 +59,11 @@ jobs:
           delete-branch: true
 
       - name: Auto approve the PR
-        if: github.actor == 'telcobot'
         uses: hmarr/auto-approve-action@v4
         with:
           review-message: "Auto approved automated PR"
 
       - name: Automerge
-        if: github.actor == 'telcobot'
         uses: pascalgn/automerge-action@v0.16.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
`github.actor` variables currently points to a person who last modified the cron expression for the workflow. This makes the jobs for auto-approve and auto-merge very fragile. 
This PR removes the condition. CI will make sure no breaking changes are introduced.