### PR TITLE
fix: update workflow to use rockcraft.skopeo

### DIFF
--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -21,9 +21,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install skopeo
+      - name: Install skopeo from rockcraft
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install --edge --classic rockcraft
       - uses: actions/download-artifact@v4
         with:
           name: rock
@@ -33,7 +33,7 @@ jobs:
           image_name="$(yq '.name' rockcraft.yaml)"
           version="$(yq '.version' rockcraft.yaml)"
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -14,9 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install skopeo
+      - name: Install skopeo from rockcraft
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install --edge --classic rockcraft
 
       - name: Install yq
         run: |
@@ -33,7 +33,7 @@ jobs:
           version="$(yq '.version' rockcraft.yaml)"
           echo "version=${version}" >> $GITHUB_ENV
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \


### PR DESCRIPTION
The versions of skopeo from universe and snap store are too old to work with recentl docker revisions. The rockcraft team noticed this and now bundle a version of skopeo that will work with newer docker engines