### PR TITLE
chore: Include hidden files in upload artifacts.

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -51,11 +51,12 @@ jobs:
         run: tox -e integration
 
       - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4
         with:
           name: tested-charm
           path: .tox/**/${{ inputs.charm-file-name }}
           retention-days: 5
+          include-hidden-files: true
 
       - name: Archive charmcraft logs
         if: failure()

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -51,7 +51,7 @@ jobs:
         run: tox -e integration
 
       - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: tested-charm
           path: .tox/**/${{ inputs.charm-file-name }}


### PR DESCRIPTION
# Description

The new minor version (should definitely have been a major version) of upload-artifact came with a breaking change where it does not include hidden files by default. This caused our publishing CI to fail.

## Reference
- https://github.com/actions/upload-artifact/releases/tag/v4.4.0
