### PR TITLE
chore: Add support for uv and move to concierge

### DIFF
--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -24,11 +24,10 @@ jobs:
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
       
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          juju-channel: 3.4/stable
-          provider: lxd
-          lxd-channel: 5.20/stable
+        run: |
+          sudo snap install concierge --classic
+          sudo concierge prepare -p machine --juju-channel "3.4/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          uv tool install tox --with tox-uv
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -32,14 +32,12 @@ jobs:
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          juju-channel: 3.4/stable
-          provider: microk8s
-          channel: 1.27-strict/stable
-          lxd-channel: 5.20/stable
-          microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"
-  
+        run: |
+          sudo snap install concierge --classic
+          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.4/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          sudo microk8s enable hostpath-storage dns metallb:10.0.0.2-10.0.0.10
+          uv tool install tox --with tox-uv
+
       - name: Enable Multus addon
         continue-on-error: true
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -42,12 +42,10 @@ jobs:
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          juju-channel: 3.4/stable
-          provider: microk8s
-          channel: 1.27-strict/stable
-          lxd-channel: 5.20/stable
+        run: |
+          sudo snap install concierge --classic
+          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.4/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          uv tool install tox --with tox-uv
   
       - name: Enable MetalLB
         if: ${{ inputs.enable-metallb == true }}

--- a/.github/workflows/lint-report.yaml
+++ b/.github/workflows/lint-report.yaml
@@ -21,8 +21,11 @@ jobs:
         with:
           ref: ${{ inputs.branch-name }}
 
+      - name: Install uv
+        run: sudo snap install --classic astral-uv
+
       - name: Install tox
-        run: pip install tox
+        run: uv tool install tox --with tox-uv
 
       - name: Run tests using tox
         run: tox -e lint

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -21,8 +21,11 @@ jobs:
         with:
           ref: ${{ inputs.branch-name }}
 
+      - name: Install uv
+        run: sudo snap install --classic astral-uv
+
       - name: Install tox
-        run: pip install tox
+        run: uv tool install tox --with tox-uv
 
       - name: Run tests using tox
         run: tox -e static

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -21,8 +21,11 @@ jobs:
         with:
           ref: ${{ inputs.branch-name }}
 
+      - name: Install uv
+        run: sudo snap install --classic astral-uv
+
       - name: Install tox
-        run: pip install tox
+        run: uv tool install tox --with tox-uv
 
       - name: Run tests using tox
         run: tox -e unit


### PR DESCRIPTION
Adds support for `uv` and move to concierge to setup the integration testing environment.

The move to concierge enables us to install `tox` with `uv` support cleanly. It also enables running the same locally for testing.

This will work for all projects, even if they are not yet migrated to `uv`. Once this is merged, tag `v2.0.0` will be created to enable including these changes in sdcore projects.