### PR TITLE
chore: update Juju version to 3.5 in the workflows

### DIFF
--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p machine --juju-channel "3.4/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          sudo concierge prepare -p machine --juju-channel "3.5/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
           uv tool install tox --with tox-uv
 
       - name: Run integration tests

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.4/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
           sudo microk8s enable hostpath-storage dns metallb:10.0.0.2-10.0.0.10
           uv tool install tox --with tox-uv
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.4/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
           uv tool install tox --with tox-uv
   
       - name: Enable MetalLB


### PR DESCRIPTION
We decided to use Juju 3.5 in SD-Core 1.5 channel. The reason why this PR updates the Juju version in CI workflows.