### PR TITLE
chore: Update workflows to latest stable releases or LTS releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-            channel: 5.20/stable
+            channel: 5.21/stable
     
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic

--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p machine --juju-channel "3.5/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          sudo concierge prepare -p machine --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
           uv tool install tox --with tox-uv
 
       - name: Run integration tests

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          sudo concierge prepare -p microk8s --microk8s-channel "1.31-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
           sudo microk8s enable hostpath-storage dns metallb:10.0.0.2-10.0.0.10
           uv tool install tox --with tox-uv
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --microk8s-channel "1.27-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          sudo concierge prepare -p microk8s --microk8s-channel "1.31-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
           uv tool install tox --with tox-uv
   
       - name: Enable MetalLB


### PR DESCRIPTION
Updates the workflows to use the latest stable releases of dependencies or LTS releases. Specifically:

- MicroK8s 1.31-strict (latest stable release)
- LXD 5.21 (latest LTS release)

Once merged, this will be tagged `v2.1.0`.