### PR TITLE
fix: Workaround for LXD sometimes failing to refresh

### DIFF
--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -26,6 +26,10 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
+
+          # Workaround for lxd sometimes failing to refresh
+          sudo snap info lxd | grep "tracking": | awk '{print $2}' | grep "5.21/stable" || sudo snap stop lxd
+
           sudo concierge prepare -p machine --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
           uv tool install tox --with tox-uv
 

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -34,6 +34,10 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
+
+          # Workaround for lxd sometimes failing to refresh
+          sudo snap info lxd | grep "tracking": | awk '{print $2}' | grep "5.21/stable" || sudo snap stop lxd
+
           sudo concierge prepare -p microk8s --microk8s-channel "1.31-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
           sudo microk8s enable hostpath-storage dns metallb:10.0.0.2-10.0.0.10
           uv tool install tox --with tox-uv

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -44,6 +44,10 @@ jobs:
       - name: Setup operator environment
         run: |
           sudo snap install concierge --classic
+
+          # Workaround for lxd sometimes failing to refresh
+          sudo snap info lxd | grep "tracking": | awk '{print $2}' | grep "5.21/stable" || sudo snap stop lxd
+
           sudo concierge prepare -p microk8s --microk8s-channel "1.31-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
           uv tool install tox --with tox-uv
   


### PR DESCRIPTION
Stop LXD if it will be refreshed to workaround an issue happening often in CI where LXD fails to refresh because of a missing socket file.