### PR TITLE
chore: Rollback concierge to stabilize CI

### DIFF
--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -23,10 +23,18 @@ jobs:
         id: charm-path
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
       
+
       - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.5/stable
+          provider: lxd
+          lxd-channel: 5.21/stable
+
+      - name: Install UV and Tox
         run: |
-          sudo snap install concierge --classic
-          sudo concierge prepare -p machine --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
+          python3 -m pip uninstall tox -y
+          sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv
 
       - name: Run integration tests

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -32,12 +32,19 @@ jobs:
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
       - name: Setup operator environment
-        run: |
-          sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --microk8s-channel "1.31-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
-          sudo microk8s enable hostpath-storage dns metallb:10.0.0.2-10.0.0.10
-          uv tool install tox --with tox-uv
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.5/stable
+          provider: microk8s
+          channel: 1.31-strict/stable
+          lxd-channel: 5.21/stable
 
+      - name: Install UV and Tox
+        run: |
+          python3 -m pip uninstall tox -y
+          sudo snap install astral-uv --classic
+          uv tool install tox --with tox-uv
+  
       - name: Enable Multus addon
         continue-on-error: true
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -42,9 +42,17 @@ jobs:
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
       - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.5/stable
+          provider: microk8s
+          channel: 1.31-strict/stable
+          lxd-channel: 5.21/stable
+
+      - name: Install UV and Tox
         run: |
-          sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --microk8s-channel "1.31-strict/stable" --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
+          python3 -m pip uninstall tox -y
+          sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv
   
       - name: Enable MetalLB


### PR DESCRIPTION
Removes `concierge` and add back `actions-operator` to stabilize CI.

Tested [here](https://github.com/canonical/sdcore-amf-k8s-operator/pull/464)