### PR TITLE
chore: Bumps charm base in promotion workflow to 24.04

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Promote Charm
         uses: canonical/charming-actions/release-charm@2.6.3
         with:
-          base-channel: 22.04
+          base-channel: 24.04
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ inputs.track-name }}/${{ env.promote-to }}


### PR DESCRIPTION
Bumps charm base in promotion workflow to 24.04