### PR TITLE
fix: Actions-operator started using pipx instead of pip

### DIFF
--- a/.github/workflows/integration-test-machine.yaml
+++ b/.github/workflows/integration-test-machine.yaml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Install UV and Tox
         run: |
-          python3 -m pip uninstall tox -y
+          pipx uninstall tox
           sudo snap install astral-uv --classic
-          uv tool install tox --with tox-uv
+          uv tool install tox --with tox-uv --force
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -42,9 +42,9 @@ jobs:
 
       - name: Install UV and Tox
         run: |
-          python3 -m pip uninstall tox -y
+          pipx uninstall tox
           sudo snap install astral-uv --classic
-          uv tool install tox --with tox-uv
+          uv tool install tox --with tox-uv --force
   
       - name: Enable Multus addon
         continue-on-error: true

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Install UV and Tox
         run: |
-          python3 -m pip uninstall tox -y
+          pipx uninstall tox
           sudo snap install astral-uv --classic
-          uv tool install tox --with tox-uv
+          uv tool install tox --with tox-uv --force
   
       - name: Enable MetalLB
         if: ${{ inputs.enable-metallb == true }}


### PR DESCRIPTION
Actions-operator started using pipx instead of pip to install Tox. This change uninstalls tox with pipx and also forces the install of tox with uv, so future changes will not cause the installation of tox to fail.