### PR TITLE
chore: do not show CVE, KEV details while logging

### DIFF
--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -61,19 +61,25 @@ jobs:
 
       - name: Compare found CVEs with KEVs
         run: |
-          set -x 
+          set -euo pipefail
+          
+          # Define the error_exit function
+          error_exit() {
+            echo "::error file=${BASH_SOURCE[1]},line=$1::Error: $2"
+            exit 1
+          }
+          
+          # Trap errors and call error_exit on termination
+          trap 'error_exit ${LINENO} "An error occurred while comparing CVEs with KEVs."' ERR
+          
           # Get the CVEs from Trivy results
           current_cves=$(jq -r '.. | .results? | arrays | .[].ruleId' trivy-results.sarif)
-          echo "Found $(wc -l <<< $current_cves) CVEs currently open"
           
           # Get the list of KEV CVEs from the KEV catalog
           kevs=$(jq -r '.vulnerabilities[] | .cveID' known_exploited_vulnerabilities.json)
-          echo "Found $(wc -l <<< $kevs) KEV CVEs"
           
           # Compare the lists of CVEs and output any common CVEs
-          echo "----Matched CVEs----"
           comm -12 <(sort <<< "$current_cves") <(sort <<< "$kevs") > matched_cvs.txt
-          echo "--------------------"
           
           # Create a SARIF template for the KEV matches
           matched_sarif=$(cat <<EOF
@@ -105,15 +111,6 @@ jobs:
           
           # Save final SARIF file
           echo "$matched_sarif" > kev_matches.sarif    
-          set +x
-
-      - name: Upload Trivy results as an artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: trivy-results
-          path: |
-            trivy-results.sarif
-            kev_matches.sarif
 
       - name: Upload CVE results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -72,6 +72,16 @@ jobs:
           # Trap errors and call error_exit on termination
           trap 'error_exit ${LINENO} "An error occurred while comparing CVEs with KEVs."' ERR
           
+          if [[ ! -s trivy-results.sarif ]]; then
+            echo "Error: trivy-results.sarif file is missing or empty."
+            exit 1
+          fi
+          
+          if ! jq empty known_exploited_vulnerabilities.json >/dev/null 2>&1; then
+            echo "Error: known_exploited_vulnerabilities.json is not valid JSON."
+            exit 1
+          fi
+          
           # Get the CVEs from Trivy results
           current_cves=$(jq -r '.. | .results? | arrays | .[].ruleId' trivy-results.sarif)
           
@@ -82,9 +92,6 @@ jobs:
           if [[ -z "$kevs" ]]; then
             echo "No KEV CVEs found in the known_exploited_vulnerabilities.json catalog."
           fi
-          
-          # Ensure current_cves is defined, even if empty
-          current_cves=${current_cves:-""}
           
           # If both current_cves and kevs are empty, skip processing
           if [[ -z "$current_cves" && -z "$kevs" ]]; then

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -75,11 +75,34 @@ jobs:
           # Get the CVEs from Trivy results
           current_cves=$(jq -r '.. | .results? | arrays | .[].ruleId' trivy-results.sarif)
           
-          # Get the list of KEV CVEs from the KEV catalog
-          kevs=$(jq -r '.vulnerabilities[] | .cveID' known_exploited_vulnerabilities.json)
+          # Extract the list of KEV CVEs from the catalog
+          kevs=$(jq -r '.vulnerabilities[] | .cveID' known_exploited_vulnerabilities.json 2>/dev/null || echo "")
           
-          # Compare the lists of CVEs and output any common CVEs
-          comm -12 <(sort <<< "$current_cves") <(sort <<< "$kevs") > matched_cvs.txt
+          # If no KEV CVEs are found, log a message and continue gracefully
+          if [[ -z "$kevs" ]]; then
+            echo "No KEV CVEs found in the known_exploited_vulnerabilities.json catalog."
+          fi
+          
+          # Ensure current_cves is defined, even if empty
+          current_cves=${current_cves:-""}
+          
+          # If both current_cves and kevs are empty, skip processing
+          if [[ -z "$current_cves" && -z "$kevs" ]]; then
+            echo "No CVEs or KEV CVEs to process. Exiting."
+            exit 0
+          fi
+          
+          # Compare CVEs and save the matched results
+          comm -12 <(sort <<< "$current_cves") <(sort <<< "$kevs") > matched_cvs.txt || {
+            echo "Error: Failed to compare CVEs."
+            exit 1
+          }
+          
+          # If matched_cvs.txt is empty, log a message and exit successfully
+          if [[ ! -s matched_cvs.txt ]]; then
+            echo "No matches found between current CVEs and the KEV catalog."
+            exit 0
+          fi
           
           # Create a SARIF template for the KEV matches
           matched_sarif=$(cat <<EOF
@@ -100,24 +123,43 @@ jobs:
           }
           EOF
           )
+          
           # Add matched KEVs to the SARIF file
           while read -r cve; do
-          matched_sarif=$(jq \
-          --arg cve "$cve" \
-          '.runs[0].tool.driver.rules += [{"id": $cve, "name": $cve, "shortDescription": {"text": "CVE matched with KEV"}, "tags": ["KEV"]}] |
-           .runs[0].results += [{"ruleId": $cve, "message": {"text": "This CVE matches the CISA KEV catalog.", "tags": ["KEV"]}}]' \
-          <<< "$matched_sarif")
+            matched_sarif=$(jq \
+              --arg cve "$cve" \
+              '.runs[0].tool.driver.rules += [{"id": $cve, "name": $cve, "shortDescription": {"text": "CVE matched with KEV"}, "tags": ["KEV"]}] |
+              .runs[0].results += [{"ruleId": $cve, "message": {"text": "This CVE matches the CISA KEV catalog.", "tags": ["KEV"]}}]' \
+              <<< "$matched_sarif") || {
+              echo "Error: jq failed while processing CVE $cve."
+              exit 1
+            }
           done < matched_cvs.txt
           
           # Save final SARIF file
-          echo "$matched_sarif" > kev_matches.sarif    
+          echo "$matched_sarif" > kev_matches.sarif || {
+            echo "Error: Failed to save SARIF file."
+            exit 1
+          }  
 
       - name: Upload CVE results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 
+      - name: Check if kev_matches.sarif file exists
+        id: check_kev_sarif_file
+        run: |
+          if [ -e kev_matches.sarif ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        outputs:
+          exists: ${{ steps.check_kev_sarif_file.outputs.exists }}
+
       - name: Upload KEV results to GitHub Security tab
+        if: ${{ steps.check_kev_sarif_file.outputs.exists == 'true' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'kev_matches.sarif'

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -155,8 +155,6 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        outputs:
-          exists: ${{ steps.check_kev_sarif_file.outputs.exists }}
 
       - name: Upload KEV results to GitHub Security tab
         if: ${{ steps.check_kev_sarif_file.outputs.exists == 'true' }}


### PR DESCRIPTION
This PR enhances the `compare found CVEs with KEVs` step in scan-rock workflow.

Here are the improvements:
1. It does not show any CVE or KEV details while logging.
2. It does not upload sarif files as artifacts. Otherwise, people can download those files and read them.
3. If any KEV does not match with CVE, uploading KEV sarif file to GH security tab is skipped.
4. The script stops immediately on errors.
5. It catches pipeline (concatenated commands) related errors.
6. Log the errors before terminating the script.
7. If a command fails `set -e` triggers the ERR signal and `trap` catches the errors. 
Then, `trap` calls the `error_exit` function that logs the errors. The script terminates after logging.


https://github.com/canonical/sdcore-amf-rock/pull/50 tests the latest version of the script.