### PR TITLE
feat: use Canonical K8s

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, X64, xlarge, jammy]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,14 +31,26 @@ jobs:
         id: charm-path
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
+      - name: Setup Canonical K8S
+        id: canonical-k8s
+        run: |
+          sudo snap install k8s --classic --channel=1.32-classic/stable
+          cat << EOF | sudo k8s bootstrap --file -
+          containerd-base-dir: /opt/containerd
+          EOF
+          sudo k8s enable network dns load-balancer local-storage
+          sudo k8s status --wait-ready --timeout 5m
+          mkdir -p ~/.kube
+          sudo k8s config > ~/.kube/config
+          echo "kubeconfig=$(sudo k8s config | base64 -w 0)" >> $GITHUB_OUTPUT
+          sudo k8s set load-balancer.cidrs="10.0.0.2-10.0.0.10" load-balancer.enabled=true load-balancer.l2-mode=true
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
+          credentials-yaml: ${{ steps.canonical-k8s.outputs.kubeconfig }}
           juju-channel: 3.6/stable
-          provider: microk8s
-          channel: 1.31-strict/stable
-          lxd-channel: 5.21/stable
-          microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"
+          provider: k8s
 
       - name: Install UV and Tox
         run: |
@@ -49,10 +61,9 @@ jobs:
       - name: Enable Multus addon
         continue-on-error: true
         run: |
-          sudo microk8s addons repo add community https://github.com/canonical/microk8s-community-addons --reference feat/strict-fix-multus
-          sudo microk8s enable multus
-          sudo microk8s kubectl -n kube-system rollout status daemonset/kube-multus-ds
-          sudo microk8s kubectl auth can-i create network-attachment-definitions
+          sudo k8s kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset-thick.yml
+          sudo k8s kubectl -n kube-system rollout status daemonset/kube-multus-ds
+          sudo k8s kubectl auth can-i create network-attachment-definitions
   
       - name: Run integration tests
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, X64, xlarge, jammy]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,13 +41,25 @@ jobs:
         id: charm-path
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
+      - name: Setup Canonical K8S
+        id: canonical-k8s
+        run: |
+          sudo snap install k8s --classic --channel=1.32-classic/stable
+          cat << EOF | sudo k8s bootstrap --file -
+          containerd-base-dir: /opt/containerd
+          EOF
+          sudo k8s enable network local-storage
+          sudo k8s status --wait-ready --timeout 5m
+          mkdir -p ~/.kube
+          sudo k8s config > ~/.kube/config
+          echo "kubeconfig=$(sudo k8s config | base64 -w 0)" >> $GITHUB_OUTPUT
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
+          credentials-yaml: ${{ steps.canonical-k8s.outputs.kubeconfig }}
           juju-channel: 3.6/stable
-          provider: microk8s
-          channel: 1.31-strict/stable
-          lxd-channel: 5.21/stable
+          provider: k8s
 
       - name: Install UV and Tox
         run: |
@@ -57,7 +69,9 @@ jobs:
   
       - name: Enable MetalLB
         if: ${{ inputs.enable-metallb == true }}
-        run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:${{ inputs.metallb-range }}"
+        run: |
+          sudo k8s enable load-balancer
+          sudo k8s set load-balancer.cidrs="${{ inputs.metallb-range }}" load-balancer.enabled=true load-balancer.l2-mode=true
 
       - name: Run integration tests
         run: |


### PR DESCRIPTION
This PR replaces `microk8s` with Canonical K8s in integration tests.

The PR has been tested in these PRs:
- `integration-test-with-multus.yaml`: https://github.com/canonical/sdcore-upf-k8s-operator/commits/TELCO-1721-use-canonical-k8s
- `integration-test.yaml`: https://github.com/canonical/sdcore-amf-k8s-operator/commits/TELCO-1721-use-canonical-k8s