### PR TITLE
fix: save K8s config allowing Juju to read it

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -50,6 +50,8 @@ jobs:
           EOF
           sudo k8s enable network local-storage
           sudo k8s status --wait-ready --timeout 5m
+          mkdir -p ~/.kube
+          sudo k8s config > ~/.kube/config
           echo "kubeconfig=$(sudo k8s config | base64 -w 0)" >> $GITHUB_OUTPUT
 
       - name: Setup operator environment


### PR DESCRIPTION
This PR fixes an issue for which Juju is not able to bootstrap `k8s` cloud due to missing `~/.kube/config` file.