### PR TITLE
fix: save K8s config allowing Juju to read it

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -41,6 +41,8 @@ jobs:
           sudo k8s enable network dns load-balancer local-storage
           sudo k8s set load-balancer.cidrs="10.0.0.2-10.0.0.10"
           sudo k8s status --wait-ready --timeout 5m
+          mkdir -p ~/.kube
+          sudo k8s config > ~/.kube/config
           echo "kubeconfig=$(sudo k8s config | base64 -w 0)" >> $GITHUB_OUTPUT
 
       - name: Setup operator environment


### PR DESCRIPTION
This PR fixes an issue for which Juju is not able to bootstrap `k8s` cloud due to missing `~/.kube/config` file in integration tests with Multus.