### PR TITLE
fix: use valid Renovate schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,10 @@
   "automerge": true,
   "automergeStrategy": "squash",
   "automergeType": "pr",
+  "baseBranches": [
+    "main",
+    "v*",
+  ],
   "platformAutomerge": true,
   "schedule": ["after 1am and before 3am on monday"],
   "lockFileMaintenance": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,10 +10,10 @@
   "automergeStrategy": "squash",
   "automergeType": "pr",
   "platformAutomerge": true,
-  "schedule": ["after 1am and before 3am every monday"],
+  "schedule": ["after 1am and before 3am on monday"],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["after 1am and before 3am every wednesday"]
+    "schedule": ["after 1am and before 3am on wednesday"],
   },
   "timezone": "Etc/UTC",
   "enabledManagers": ["pep621", "github-actions", "terraform"],


### PR DESCRIPTION
When running locally a simulation of renovate on any repo, I get the following output:
```
$ RENOVATE_CONFIG_FILE=.github/renovate.json5 npx renovate --token="${GITHUB_TOKEN}" --schedule="after 1am and before 3am every monday" --require-config="ignored" --dry-run="full" canonical/sdcore-amf-k8s-operator
...
WARN: Invalid schedule: Failed to parse "after 1am and before 2am every monday" (repository=canonical/sdcore-amf-k8s-operator, branch=renovate/github-actions)
 INFO: DRY-RUN: Would commit files to branch renovate/github-actions (repository=canonical/sdcore-amf-k8s-operator, branch=renovate/github-actions)
 WARN: Invalid schedule: Failed to parse "after 1am and before 2am every monday" (repository=canonical/sdcore-amf-k8s-operator, branch=renovate/major-python-dependencies)
 INFO: DRY-RUN: Would commit files to branch renovate/major-python-dependencies (repository=canonical/sdcore-amf-k8s-operator, branch=renovate/major-python-dependencies)
 WARN: Invalid schedule: Failed to parse "after 1am and before 2am every monday" (repository=canonical/sdcore-amf-k8s-operator, branch=renovate/python-dependencies)
 INFO: DRY-RUN: Would commit files to branch renovate/python-dependencies (repository=canonical/sdcore-amf-k8s-operator, branch=renovate/python-dependencies)
 WARN: Invalid schedule: Failed to parse "after 1am and before 2am every monday" (repository=canonical/sdcore-amf-k8s-operator, branch=renovate/terraform)
...
```
Also, when running the config validator (`npx --yes --package renovate -- renovate-config-validator renovate.json5`) it warns about necessity to migrate the config and adding `baseBranches` to use `matchBaseBranches` in `packageRules`.