### PR TITLE
feat: add Jhack to integration tests and bump K8s version

### DIFF
--- a/.github/workflows/integration-test-with-multus.yaml
+++ b/.github/workflows/integration-test-with-multus.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Canonical K8S
         id: canonical-k8s
         run: |
-          sudo snap install k8s --classic --channel=1.32-classic/stable
+          sudo snap install k8s --classic --channel=1.33-classic/stable
           cat << EOF | sudo k8s bootstrap --file -
           containerd-base-dir: /opt/containerd
           EOF

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -61,10 +61,11 @@ jobs:
           juju-channel: 3.6/stable
           provider: k8s
 
-      - name: Install UV and Tox
+      - name: Install UV, Tox and Jhack
         run: |
           pipx uninstall tox
           sudo snap install astral-uv --classic
+          sudo snap install jhack
           uv tool install tox --with tox-uv --force
   
       - name: Enable MetalLB

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Canonical K8S
         id: canonical-k8s
         run: |
-          sudo snap install k8s --classic --channel=1.32-classic/stable
+          sudo snap install k8s --classic --channel=1.33-classic/stable
           cat << EOF | sudo k8s bootstrap --file -
           containerd-base-dir: /opt/containerd
           EOF

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -66,6 +66,7 @@ jobs:
           pipx uninstall tox
           sudo snap install astral-uv --classic
           sudo snap install jhack
+          sudo snap connect jhack:dot-local-share-juju snapd
           uv tool install tox --with tox-uv --force
   
       - name: Enable MetalLB


### PR DESCRIPTION
This PR adds `jhack` to the integration tests to allow testing the HA scenario and aligns Canonical K8s version to the one used by E2E tests.