### PR TITLE
chore: removing schedule temporarily

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,6 @@
     "v*",
   ],
   "platformAutomerge": true,
-  "schedule": ["after 1am and before 3am on monday"],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["after 1am and before 3am on wednesday"],


### PR DESCRIPTION
The renovate does not  create PR's for some some packages in the given schedule.  We would like remove schedule temporarily to see what happens for the investigation. Please note that schedule will be added after solving the issue.