### PR TITLE
chore: enable dns for k8s

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -48,7 +48,7 @@ jobs:
           cat << EOF | sudo k8s bootstrap --file -
           containerd-base-dir: /opt/containerd
           EOF
-          sudo k8s enable network local-storage
+          sudo k8s enable network local-storage dns
           sudo k8s status --wait-ready --timeout 5m
           mkdir -p ~/.kube
           sudo k8s config > ~/.kube/config


### PR DESCRIPTION
While preparing E2E test environment, DNS should be enabled in Canonical K8s. 
Data platform team gave feedback that MongoDB error appears in 6/edge may happen because of  disabled DNS.
Hence, this PR will enable it.